### PR TITLE
 Martynas K. Add FFTW libraries for Harmonie images of Centos8/Rocky

### DIFF
--- a/docker/centos8_harmonie.docker
+++ b/docker/centos8_harmonie.docker
@@ -30,6 +30,8 @@ RUN dnf install automake.noarch \
         eccodes-data.noarch \
         eccodes-devel.x86_64 \
         eccodes-doc.noarch \
+        fftw.x86_64 \
+        fftw-devel.x86_64 \
         flex.x86_64 \
         gcc-c++.x86_64 \
         gdal-devel.x86_64 \

--- a/docker/rocky8_harmonie.docker
+++ b/docker/rocky8_harmonie.docker
@@ -25,6 +25,8 @@ RUN dnf install automake.noarch \
         eccodes-data.noarch \
         eccodes-devel.x86_64 \
         eccodes-doc.noarch \
+        fftw.x86_64 \
+        fftw-devel.x86_64 \
         flex.x86_64 \
         gcc-c++.x86_64 \
         gdal-devel.x86_64 \


### PR DESCRIPTION
 FFTW seems to be required by Harmonie images as well for Centos8/Rocky, so far present in  Musc only.